### PR TITLE
ORCOMP-627: Add timer to public methods in ProjectManager class

### DIFF
--- a/src/Orc.ProjectManagement/FodyWeavers.xml
+++ b/src/Orc.ProjectManagement/FodyWeavers.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers VerifyAssembly="true" VerifyIgnoreCodes="0x80131252,0x80131869" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <MethodTimer/>
   <ModuleInit />
   <Obsolete />
   <Catel />

--- a/src/Orc.ProjectManagement/Managers/ProjectManager.cs
+++ b/src/Orc.ProjectManagement/Managers/ProjectManager.cs
@@ -325,7 +325,6 @@ namespace Orc.ProjectManagement
             }
         }
 
-        [Time]
         protected virtual async Task<IProject> ReadProjectAsync(string location)
         {
             var projectReader = _projectSerializerSelector.GetReader(location);
@@ -341,7 +340,6 @@ namespace Orc.ProjectManagement
             return project;
         }
 
-        [Time]
         protected virtual Task<bool> WriteProjectAsync(IProject project, string location)
         {
             var projectWriter = _projectSerializerSelector.GetWriter(location);

--- a/src/Orc.ProjectManagement/Managers/ProjectManager.cs
+++ b/src/Orc.ProjectManagement/Managers/ProjectManager.cs
@@ -19,6 +19,7 @@ namespace Orc.ProjectManagement
     using Catel.Logging;
     using Catel.Reflection;
     using Catel.Threading;
+    using MethodTimer;
 
     public class ProjectManager : IProjectManager, INeedCustomInitialization
     {
@@ -126,6 +127,7 @@ namespace Orc.ProjectManagement
         #endregion
 
         #region IProjectManager Members
+        [Time]
         public async Task InitializeAsync()
         {
             var locations = (from location in await _projectInitializer.GetInitialLocationsAsync()
@@ -148,6 +150,7 @@ namespace Orc.ProjectManagement
                 : RefreshAsync(project);
         }
 
+        [Time]
         public Task<bool> RefreshAsync(IProject project)
         {
             Argument.IsNotNull(() => project);
@@ -155,6 +158,7 @@ namespace Orc.ProjectManagement
             return SynchronizeProjectOperationAsync(project.Location, () => SyncedRefreshAsync(project));
         }
 
+        [Time]
         public Task<bool> LoadAsync(string location)
         {
             Argument.IsNotNullOrWhitespace("location", location);
@@ -172,6 +176,7 @@ namespace Orc.ProjectManagement
             });
         }
 
+        [Time]
         public Task<bool> LoadInactiveAsync(string location)
         {
             Argument.IsNotNullOrWhitespace("location", location);
@@ -196,6 +201,7 @@ namespace Orc.ProjectManagement
             return SaveAsync(project, location);
         }
 
+        [Time]
         public async Task<bool> SaveAsync(IProject project, string location = null)
         {
             if (string.IsNullOrWhiteSpace(location))
@@ -221,6 +227,7 @@ namespace Orc.ProjectManagement
                 : CloseAsync(project);
         }
 
+        [Time]
         public Task<bool> CloseAsync(IProject project)
         {
             Argument.IsNotNull(() => project);
@@ -230,6 +237,7 @@ namespace Orc.ProjectManagement
             return SynchronizeProjectOperationAsync(location, () => SyncedCloseAsync(project));
         }
 
+        [Time]
         public async Task<bool> SetActiveProjectAsync(IProject project)
         {
             using (await _commonAsyncLock.LockAsync())
@@ -317,6 +325,7 @@ namespace Orc.ProjectManagement
             }
         }
 
+        [Time]
         protected virtual async Task<IProject> ReadProjectAsync(string location)
         {
             var projectReader = _projectSerializerSelector.GetReader(location);
@@ -332,6 +341,7 @@ namespace Orc.ProjectManagement
             return project;
         }
 
+        [Time]
         protected virtual Task<bool> WriteProjectAsync(IProject project, string location)
         {
             var projectWriter = _projectSerializerSelector.GetWriter(location);

--- a/src/Orc.ProjectManagement/Orc.ProjectManagement.csproj
+++ b/src/Orc.ProjectManagement/Orc.ProjectManagement.csproj
@@ -14,13 +14,14 @@
     <!-- SonarQube requires a project guid -->
     <ProjectGuid>49323BB6-1208-4760-A989-27BB6F43CD49</ProjectGuid>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Catel.Core" Version="5.12.15" />
     <PackageReference Include="Catel.Fody" Version="4.7.0" PrivateAssets="all" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MethodTimer.Fody" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="ModuleInit.Fody" Version="2.1.1" PrivateAssets="all" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="all" />
     <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.3.0" />

--- a/src/Orc.ProjectManagement/Serialization/ProjectReaderBase.cs
+++ b/src/Orc.ProjectManagement/Serialization/ProjectReaderBase.cs
@@ -10,11 +10,13 @@ namespace Orc.ProjectManagement
     using System.Threading.Tasks;
     using Catel;
     using Catel.Logging;
+    using MethodTimer;
 
     public abstract class ProjectReaderBase : IProjectReader
     {
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
 
+        [Time]
         public async Task<IProject> ReadAsync(string location)
         {
             Argument.IsNotNullOrWhitespace(() => location);

--- a/src/Orc.ProjectManagement/Serialization/ProjectWriterBase.cs
+++ b/src/Orc.ProjectManagement/Serialization/ProjectWriterBase.cs
@@ -10,12 +10,14 @@ namespace Orc.ProjectManagement
     using System.Threading.Tasks;
     using Catel;
     using Catel.Logging;
+    using MethodTimer;
 
     public abstract class ProjectWriterBase<TProject> : IProjectWriter
         where TProject : IProject
     {
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
 
+        [Time]
         public async Task<bool> WriteAsync(IProject project, string location)
         {
             Argument.IsNotNull(() => project);


### PR DESCRIPTION
### Description of Change ###

Add Fody.MethodTimer to public methods in ProjectManager class to automatically get the method execution duration for Saving, Loading, Refreshing etc...

### Issues Resolved ### 

https://sesolutions.atlassian.net/browse/ORCOMP-627

### API Changes ###

None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- WPF
- UWP
- iOS
- Android

### Behavioral Changes ###

Add timings to log debug messages

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
